### PR TITLE
feat: implemented set Disabled Date

### DIFF
--- a/app/src/main/java/io/blackbox_vision/materialcalendarview/sample/view/MainActivity.java
+++ b/app/src/main/java/io/blackbox_vision/materialcalendarview/sample/view/MainActivity.java
@@ -89,15 +89,19 @@ public final class MainActivity extends AppCompatActivity implements MainView {
 
     @Override
     public void prepareCalendarView() {
+        Calendar disabledCal = Calendar.getInstance();
+        disabledCal.set(Calendar.DATE, disabledCal.get(Calendar.DATE) - 1);
+
         calendarView.setFirstDayOfWeek(Calendar.MONDAY)
                 .setOnDateClickListener(this::onDateClick)
                 .setOnMonthChangeListener(this::onMonthChange)
                 .setOnDateLongClickListener(this::onDateLongClick)
-                .setOnMonthTitleClickListener(this::onMonthTitleClick);
+                .setOnMonthTitleClickListener(this::onMonthTitleClick)
+                .setDisabledDate(disabledCal.getTime());
 
         if (calendarView.isMultiSelectDayEnabled()) {
             calendarView.setOnMultipleDaySelectedListener((month, dates) -> {
-               //Do something with your current selection
+                //Do something with your current selection
             });
         }
 

--- a/materialcalendarview/src/main/java/io/blackbox_vision/materialcalendarview/internal/data/Day.java
+++ b/materialcalendarview/src/main/java/io/blackbox_vision/materialcalendarview/internal/data/Day.java
@@ -5,7 +5,7 @@ import java.util.Date;
 import java.util.Locale;
 
 
-public final class Day {
+public final class Day implements Comparable<Day> {
     private int day;
     private int month;
     private int year;
@@ -104,5 +104,23 @@ public final class Day {
 
     public Date toDate(Locale locale) {
         return toCalendar(locale).getTime();
+    }
+
+    @Override
+    public int compareTo(Day otherDay) {
+        if (year == otherDay.year) {
+            if (month == otherDay.month) {
+                return this.day - otherDay.day;
+            } else {
+                return this.month - otherDay.month;
+            }
+        } else {
+            return this.year - otherDay.year;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return day + "-" + month + "-" + year;
     }
 }

--- a/materialcalendarview/src/main/java/io/blackbox_vision/materialcalendarview/internal/utils/CalendarUtils.java
+++ b/materialcalendarview/src/main/java/io/blackbox_vision/materialcalendarview/internal/utils/CalendarUtils.java
@@ -106,8 +106,9 @@ public final class CalendarUtils {
 
                 if (helper.isWithinCurrentMonth(i, j)) {
                     Calendar c = Calendar.getInstance(Locale.getDefault());
-                    c.set(Calendar.DAY_OF_MONTH, n[j]);
+
                     c.add(Calendar.MONTH, index);
+                    c.set(Calendar.DAY_OF_MONTH, n[j]);
 
                     int m = getMonth(c);
                     int y = getYear(c);
@@ -152,8 +153,8 @@ public final class CalendarUtils {
                 } else {
                     Calendar c = Calendar.getInstance(Locale.getDefault());
 
-                    c.set(Calendar.DAY_OF_MONTH, n[j]);
                     c.add(Calendar.MONTH, index);
+                    c.set(Calendar.DAY_OF_MONTH, n[j]);
 
                     d.setDay(n[j])
                      .setMonth(getMonth(c))


### PR DESCRIPTION
Now, users will be able to set a disabled date for the calendar. When disabled date is set, the users will not be able to select dates prior to and including that date. The background and textColor of the disabled date will resemble overflow dates.