### PR TITLE
Adding a helper to enable jump to today for consumers

### DIFF
--- a/materialcalendarview/src/main/java/io/blackbox_vision/materialcalendarview/view/CalendarView.java
+++ b/materialcalendarview/src/main/java/io/blackbox_vision/materialcalendarview/view/CalendarView.java
@@ -354,6 +354,11 @@ public final class CalendarView extends LinearLayout {
         }
     }
 
+    public void onGotoTodayClick(@NonNull View v) {
+        currentMonthIndex = 0;
+        updateCalendarOnTouch();
+    }
+
     public void onNextButtonClick(@NonNull View v) {
         currentMonthIndex++;
         updateCalendarOnTouch();


### PR DESCRIPTION
@JonatanSalas  Please Review

Adding a helper to enable the consumers to jump to today. The reason to add this is the currentMonthIndex is not visible to the consumer.

Fix for https://github.com/BlackBoxVision/material-calendar-view/issues/41